### PR TITLE
Clear up rfc822 vs rfc2822 confusion. 2-digit year in one.

### DIFF
--- a/lib/strftime.ex
+++ b/lib/strftime.ex
@@ -27,8 +27,8 @@ defmodule Strftime do
     iso_time: "%H:%M:%S",
     iso_datetime: "%Y-%m-%dT%H:%M:%S%:z",
     iso_naive_datetime: "%Y-%m-%dT%H:%M:%S",
-    # rfc822: "%a, %d %b %Y %H:%M:%S %z",
-    # rfc2822: "%a, %d %b %Y %H:%M:%S %z", ???
+    # rfc822: "%a, %d %b %y %H:%M:%S %z",
+    # rfc2822: "%a, %d %b %Y %H:%M:%S %z",
     # httpdate: "%a, %d %b %Y %H:%M:%S %Z",
 
   ]


### PR DESCRIPTION
From a close look at http://man7.org/linux/man-pages/man3/strftime.3.html#EXAMPLE 🧐
