### PR TITLE
name is unique enough

### DIFF
--- a/lib/interpreter.ex
+++ b/lib/interpreter.ex
@@ -91,7 +91,7 @@ defmodule TimeFormat.Interpreter do
           {other, acc}
       end)
       |> elem(1)
-      |> Enum.uniq()
+      |> Enum.uniq_by(fn {name, _} -> name end)
     end
   end
 


### PR DESCRIPTION
If the AST contains metadata (when say e.g. compiling as part of ElixirLS), this can result in duplicate elements and breaks the compile